### PR TITLE
Move organization_seats_checker workflow file into example directory.

### DIFF
--- a/example/workflow/organization_seats_checker.yml
+++ b/example/workflow/organization_seats_checker.yml
@@ -14,11 +14,15 @@ jobs:
 
       - name: Show seats
         id: seats
-        uses: ./
+        uses: M-Yamashita01/organization-seats-checker@v1
         env:
           INPUT_GITHUB_TOKEN: ${{ secrets.READ_ORG_TOKEN }}
-          MEMBERSHIP_FILE_PATH: '${{ github.workspace }}/spec/fixtures/membership.tf'
-          REPOSITORY_COLLABORATOR_FILE_PATH: '${{ github.workspace }}/spec/fixtures/repository_collaborator.tf'
+          # Set absolute file path to the terraform file containing the github_membership resources.
+          # Example: '${{ github.workspace }}/membership.tf'
+          MEMBERSHIP_FILE_PATH: '' 
+          # Set absolute file path to the terraform file containing the github_repository_collaborator resources.
+          # Example: '${{ github.workspace }}/repository_collaborator.tf'
+          REPOSITORY_COLLABORATOR_FILE_PATH: '${{ github.workspace }}/repository_collaborator.tf'
 
       - name: Post comments
         uses: actions/github-script@v5


### PR DESCRIPTION
Because it is unnecessary to run this action in this repository, move the file.
Write example file path for setting terraform files in workflow files.