### PR TITLE
Get organization name from environment variables

### DIFF
--- a/example/workflow/organization_seats_checker.yml
+++ b/example/workflow/organization_seats_checker.yml
@@ -22,7 +22,7 @@ jobs:
           MEMBERSHIP_FILE_PATH: '' 
           # Set absolute file path to the terraform file containing the github_repository_collaborator resources.
           # Example: '${{ github.workspace }}/repository_collaborator.tf'
-          REPOSITORY_COLLABORATOR_FILE_PATH: '${{ github.workspace }}/repository_collaborator.tf'
+          REPOSITORY_COLLABORATOR_FILE_PATH: ''
           ORGANIZATION_NAME: ''
 
       - name: Post comments

--- a/example/workflow/organization_seats_checker.yml
+++ b/example/workflow/organization_seats_checker.yml
@@ -23,6 +23,7 @@ jobs:
           # Set absolute file path to the terraform file containing the github_repository_collaborator resources.
           # Example: '${{ github.workspace }}/repository_collaborator.tf'
           REPOSITORY_COLLABORATOR_FILE_PATH: '${{ github.workspace }}/repository_collaborator.tf'
+          ORGANIZATION_NAME: ''
 
       - name: Post comments
         uses: actions/github-script@v5

--- a/lib/config_validator.rb
+++ b/lib/config_validator.rb
@@ -5,10 +5,11 @@ require_relative 'logging'
 class ConfigValidator
   include Logging
 
-  def initialize(access_token:, membership_file_path:, repository_collaborator_file_path:)
+  def initialize(access_token:, membership_file_path:, repository_collaborator_file_path:, organization_name:)
     @access_token = access_token
     @membership_file_path = membership_file_path
     @repository_collaborator_file_path = repository_collaborator_file_path
+    @organization_name = organization_name
   end
 
   def validate?
@@ -25,6 +26,11 @@ class ConfigValidator
     unless File.readable?(@repository_collaborator_file_path)
       logger.error("repository collaborator file is not readable.
         repository collaborator file path: #{@membership_file_path}")
+      return false
+    end
+
+    if @organization_name.nil? || @organization_name.empty?
+      logger.error('organization name is empty.')
       return false
     end
 

--- a/lib/organization_seats_checker.rb
+++ b/lib/organization_seats_checker.rb
@@ -13,6 +13,7 @@ class OrganizationSeatsChecker
     @access_token = ENV['GITHUB_PERSONAL_ACCESS_TOKEN']
     @membership_file_path = ENV['MEMBERSHIP_FILE_PATH']
     @repository_collaborator_file_path = ENV['REPOSITORY_COLLABORATOR_FILE_PATH']
+    @organization_name = ENV['ORGANIZATION_NAME']
   end
 
   def run
@@ -20,7 +21,8 @@ class OrganizationSeatsChecker
       ConfigValidator.new(
         access_token: @access_token,
         membership_file_path: @membership_file_path,
-        repository_collaborator_file_path: @repository_collaborator_file_path
+        repository_collaborator_file_path: @repository_collaborator_file_path,
+        organization_name: @organization_name
       )
     unless config_validator.validate?
       logger.error('environment variable is invalid.')
@@ -46,7 +48,7 @@ class OrganizationSeatsChecker
 
   def github_organization_seats
     github_organization =
-      GitHubOrganization.new(access_token: @access_token, organization_name: 'my-organization-sandbox')
+      GitHubOrganization.new(access_token: @access_token, organization_name: @organization_name)
     github_organization.seats
   end
 

--- a/spec/config_validator_spec.rb
+++ b/spec/config_validator_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe ConfigValidator do
     let(:access_token) { 'Sample Access Token' }
     let(:membership_file_path) { "#{__dir__}/fixtures/membership.tf" }
     let(:repository_collaborator_file_path) { "#{__dir__}/fixtures/repository_collaborator.tf" }
+    let(:organization_name) { 'organization-test' }
 
     let(:config_validator) do
       ConfigValidator.new(
         access_token: access_token,
         membership_file_path: membership_file_path,
-        repository_collaborator_file_path: repository_collaborator_file_path
+        repository_collaborator_file_path: repository_collaborator_file_path,
+        organization_name: organization_name
       )
     end
 
@@ -44,8 +46,14 @@ RSpec.describe ConfigValidator do
       it { expect(config_validator.validate?).to be_falsey }
     end
 
-    context 'Repository Collaborator file path is nil' do
+    context 'Repository Collaborator file path is empty' do
       let(:repository_collaborator_file_path) { '' }
+
+      it { expect(config_validator.validate?).to be_falsey }
+    end
+
+    context 'Organization Name is empty' do
+      let(:organization_name) { '' }
 
       it { expect(config_validator.validate?).to be_falsey }
     end

--- a/spec/config_validator_spec.rb
+++ b/spec/config_validator_spec.rb
@@ -21,10 +21,6 @@ RSpec.describe ConfigValidator do
     subject { config_validator.validate }
 
     context 'All environment variables are valid.' do
-      let(:access_token) { 'Sample Access Token' }
-      let(:membership_file_path) { "#{__dir__}/fixtures/membership.tf" }
-      let(:repository_collaborator_file_path) { "#{__dir__}/fixtures/repository_collaborator.tf" }
-
       it { expect(config_validator.validate?).to be_truthy }
     end
 
@@ -54,6 +50,12 @@ RSpec.describe ConfigValidator do
 
     context 'Organization Name is empty' do
       let(:organization_name) { '' }
+
+      it { expect(config_validator.validate?).to be_falsey }
+    end
+
+    context 'Organization Name is nil' do
+      let(:organization_name) { nil }
 
       it { expect(config_validator.validate?).to be_falsey }
     end

--- a/spec/organization_seats_checker_spec.rb
+++ b/spec/organization_seats_checker_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe OrganizationSeatsChecker do
       ENV['GITHUB_PERSONAL_ACCESS_TOKEN'] = 'Sample Access Token'
       ENV['MEMBERSHIP_FILE_PATH'] = "#{__dir__}/fixtures/membership.tf"
       ENV['REPOSITORY_COLLABORATOR_FILE_PATH'] = "#{__dir__}/fixtures/repository_collaborator.tf"
+      ENV['ORGANIZATION_NAME'] = 'rganization-test'
 
       agent = Sawyer::Agent.new(
         'https://api.github.com',


### PR DESCRIPTION
Because the organization name was hardcoded in codes, we get it from environment variables.

And refactoring spec and example workflow. 
- Because there was a test case that was missing, add test.
- Delete unnecessary string in an example workflow.